### PR TITLE
Fix bug with parent login after adding children

### DIFF
--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -5,7 +5,8 @@
  */
 var mongoose = require('mongoose'),
 	Schema = mongoose.Schema,
-	crypto = require('crypto');
+	crypto = require('crypto'),
+	validator = require('validator');
 
 /**
  * A Validation function for local strategy properties
@@ -108,7 +109,8 @@ var UserSchema = new Schema({
  * Hook a pre save method to hash the password
  */
 UserSchema.pre('save', function(next) {
-	if (this.password && this.password.length > 6) {
+	// Check to make sure password isn't already base64 encoded before hashing and encoding again -- XXX: assumes user won't use base64 encoded string
+	if (this.password && this.password.length > 6 && !validator.isBase64(this.password)) {
 		this.salt = new Buffer(crypto.randomBytes(16).toString('base64'), 'base64');
 		this.password = this.hashPassword(this.password);
 	}

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "passport-twitter": "~1.0.2",
     "serve-favicon": "~2.1.6",
     "socket.io": "~1.1.0",
-    "swig": "~1.4.1"
+    "swig": "~1.4.1",
+    "validator": "^4.2.1"
   },
   "devDependencies": {
     "supertest": "~0.14.0",


### PR DESCRIPTION
User's password was being re-hashed due to Mongoose save pre-hook.

Fix: added validator package from npm to use it's isBase64() function.

Question: Will users ever type a correct base64 string as their password? Should this include the hashed, encoded password's length?

[Finishes #107098296]
