### PR TITLE
remove child password, salt, etc fields from parent object

### DIFF
--- a/modules/users/server/config/users.server.config.js
+++ b/modules/users/server/config/users.server.config.js
@@ -18,7 +18,7 @@ module.exports = function(app, db) {
 	passport.deserializeUser(function(id, done) {
 		User.findOne({
 			_id: id
-		}, '-salt -password').populate('children', '-password -salt -provider -roles -email').exec(function(err, user) {
+		}, '-salt -password').populate('children', '-password -salt').exec(function(err, user) {
 			done(err, user);
 		});
 	});

--- a/modules/users/server/config/users.server.config.js
+++ b/modules/users/server/config/users.server.config.js
@@ -18,7 +18,7 @@ module.exports = function(app, db) {
 	passport.deserializeUser(function(id, done) {
 		User.findOne({
 			_id: id
-		}, '-salt -password').populate('children').exec(function(err, user) {
+		}, '-salt -password').populate('children', '-password -salt -provider -roles -email').exec(function(err, user) {
 			done(err, user);
 		});
 	});


### PR DESCRIPTION
For security reasons, do not send the user the full user object of their children

[Finishes #107456002]
[Delivers #107456002]
